### PR TITLE
Validate in neovim target

### DIFF
--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -9,7 +9,7 @@ let g:slime_target = "neovim"
 
 #### Manual/Prompted Configuration
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values. Unless the user uses `escape`s (presses the escape key) from the input, the default presented option will be used.
+When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 

--- a/assets/doc/targets/neovim.md
+++ b/assets/doc/targets/neovim.md
@@ -9,13 +9,14 @@ let g:slime_target = "neovim"
 
 #### Manual/Prompted Configuration
 
-When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested.
+When you invoke `vim-slime` for the first time, you will be prompted for more configuration. The last terminal you opened before calling vim-slime will determine which `job-id` is presented as default. If that terminal is closed, one of the previously opened terminals will be suggested on subsequent configurations. The user can tab through a popup menu of valid configuration values. Unless the user uses `escape`s (presses the escape key) from the input, the default presented option will be used.
 
 To use the terminal's PID as input instead of Neovim's internal job-id of the terminal:
 
 ```vim
 let g:slime_input_pid=1
 ```
+
 PIDs of processes of potential target terminals are visible to Neovim on Windows as well as MacOS and Linux.
 
 ##### Process Identification

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -23,7 +23,7 @@ function! slime#targets#neovim#config() abort
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
     endif
-    let pid_in = input("pid: ", default_pid)
+    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid)
     let id_in = s:translate_pid_to_id(pid_in)
   else
     if exists("g:slime_get_jobid")
@@ -33,7 +33,7 @@ function! slime#targets#neovim#config() abort
       if !empty(default_jobid)
         let default_jobid = str2nr(default_jobid)
       endif
-      let id_in = input("jobid: ", default_jobid)
+      let id_in = input("Configuring vim-slime. Input jobid: ", default_jobid)
       let id_in = str2nr(id_in)
     endif
     let pid_in = s:translate_id_to_pid(id_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -39,164 +39,164 @@ function! slime#targets#neovim#config() abort
     let pid_in = s:translate_id_to_pid(id_in)
   endif
 
-    let b:slime_config["jobid"] = id_in
-    let b:slime_config["pid"] = pid_in
+  let b:slime_config["jobid"] = id_in
+  let b:slime_config["pid"] = pid_in
 
-    if exists("b:slime_config")
-      if !s:ValidConfig(b:slime_config)
-        unlet b:slime_config
-      endif
-    endif
-
-  endfunction
-
-  function! slime#targets#neovim#send(config, text)
-    if  s:ValidConfig()
-
-      " Neovim jobsend is fully asynchronous, it causes some problems with
-      " iPython %cpaste (input buffering: not all lines sent over)
-      " So this `write_paste_file` can help as a small lock & delay
-      call slime#common#write_paste_file(a:text)
-      call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
-      " if b:slime_config is {"jobid": ""} and not configured
-      " then unset it for automatic configuration next time
-      if b:slime_config["jobid"]  == ""
-        unlet b:slime_config
-      endif
-
-
-    else "remove invalid configs
+  if exists("b:slime_config")
+    if !s:ValidConfig(b:slime_config)
       unlet b:slime_config
     endif
-  endfunction
+  endif
 
-  function! slime#targets#neovim#SlimeAddChannel()
-    if !exists("g:slime_last_channel")
-      let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
-    else
-      call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
+endfunction
+
+function! slime#targets#neovim#send(config, text)
+  if  s:ValidConfig()
+
+    " Neovim jobsend is fully asynchronous, it causes some problems with
+    " iPython %cpaste (input buffering: not all lines sent over)
+    " So this `write_paste_file` can help as a small lock & delay
+    call slime#common#write_paste_file(a:text)
+    call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+    " if b:slime_config is {"jobid": ""} and not configured
+    " then unset it for automatic configuration next time
+    if b:slime_config["jobid"]  == ""
+      unlet b:slime_config
     endif
-  endfunction
 
-  function! slime#targets#neovim#SlimeClearChannel()
-    let current_buffer_jobid = &channel
 
-    let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
-          \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
+  else "remove invalid configs
+    unlet b:slime_config
+  endif
+endfunction
 
-    for buf in related_bufs
-      call setbufvar(buf['bufnr'], 'slime_config', {})
-    endfor
+function! slime#targets#neovim#SlimeAddChannel()
+  if !exists("g:slime_last_channel")
+    let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
+  else
+    call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
+  endif
+endfunction
 
-    if !exists("g:slime_last_channel")
-      if exists("b:slime_config")
-        unlet b:slime_config
-      endif
-      return
-    elseif len(g:slime_last_channel) == 1
-      unlet g:slime_last_channel
-      if exists("b:slime_config")
-        unlet b:slime_config
-      endif
-    else
-      let bufinfo = s:get_filter_bufinfo()
+function! slime#targets#neovim#SlimeClearChannel()
+  let current_buffer_jobid = &channel
 
-      " tests if using a version of Neovim that
-      " doesn't automatically close buffers when closed
-      " or there is no autocommand that does that
-      if len(bufinfo) == len(g:slime_last_channel)
-        call filter(bufinfo, {_, val -> val != current_buffer_jobid})
-      endif
+  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
+        \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
 
-      call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
+  for buf in related_bufs
+    call setbufvar(buf['bufnr'], 'slime_config', {})
+  endfor
 
+  if !exists("g:slime_last_channel")
+    if exists("b:slime_config")
+      unlet b:slime_config
     endif
-  endfunction
+    return
+  elseif len(g:slime_last_channel) == 1
+    unlet g:slime_last_channel
+    if exists("b:slime_config")
+      unlet b:slime_config
+    endif
+  else
+    let bufinfo = s:get_filter_bufinfo()
 
-  function! s:get_filter_bufinfo()
-    let bufinfo = getbufinfo()
-    "getting terminal buffers
+    " tests if using a version of Neovim that
+    " doesn't automatically close buffers when closed
+    " or there is no autocommand that does that
+    if len(bufinfo) == len(g:slime_last_channel)
+      call filter(bufinfo, {_, val -> val != current_buffer_jobid})
+    endif
 
-    call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
-          \ && has_key(val['variables'], "terminal_job_pid")
-          \    && get(val,"listed",0)})
-    " only need the job id
-    call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+    call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
 
-    return bufinfo
-  endfunction
+  endif
+endfunction
 
-  function! s:translate_pid_to_id(pid)
-    for ch in g:slime_last_channel
-      if ch['pid'] == a:pid
-        return ch['jobid']
-      endif
-    endfor
-    return -1
-  endfunction
+function! s:get_filter_bufinfo()
+  let bufinfo = getbufinfo()
+  "getting terminal buffers
 
-  function! s:translate_id_to_pid(id)
+  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
+        \ && has_key(val['variables'], "terminal_job_pid")
+        \    && get(val,"listed",0)})
+  " only need the job id
+  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+
+  return bufinfo
+endfunction
+
+function! s:translate_pid_to_id(pid)
+  for ch in g:slime_last_channel
+    if ch['pid'] == a:pid
+      return ch['jobid']
+    endif
+  endfor
+  return -1
+endfunction
+
+function! s:translate_id_to_pid(id)
+  let pid_out = -1
+  try
+    let pid_out = jobpid(a:id)
+  catch /E900: Invalid channel id/
     let pid_out = -1
-    try
-      let pid_out = jobpid(a:id)
-    catch /E900: Invalid channel id/
-      let pid_out = -1
-    endtry
-    return pid_out
-  endfunction
+  endtry
+  return pid_out
+endfunction
 
 
-  " "checks that a configuration is valid
-  " returns boolean of whether the supplied config is valid
-  function! s:ValidConfig(config) abort
+" "checks that a configuration is valid
+" returns boolean of whether the supplied config is valid
+function! s:ValidConfig(config) abort
 
-    if s:NotExistsLastChannel()
-      echo "\nTerminal not detected."
-      return 0
-    endif
+  if s:NotExistsLastChannel()
+    echo "\nTerminal not detected."
+    return 0
+  endif
 
-    if !exists("a:config") ||  a:config is v:null
-      echo "\nConfig does not exist."
-      return 0
-    endif
+  if !exists("a:config") ||  a:config is v:null
+    echo "\nConfig does not exist."
+    return 0
+  endif
 
-    " Ensure the config is a dictionary and a previous channel exists
-    if type(a:config) != v:t_dict
-      echo "\nConfig type not valid."
-      return 0
-    endif
+  " Ensure the config is a dictionary and a previous channel exists
+  if type(a:config) != v:t_dict
+    echo "\nConfig type not valid."
+    return 0
+  endif
 
-    if empty(a:config)
-      echo "\nConfig is empty."
-      return 0
-    endif
+  if empty(a:config)
+    echo "\nConfig is empty."
+    return 0
+  endif
 
-    " Ensure the correct keys exist within the configuration
-    if !(has_key(a:config, 'jobid'))
-      echo "\nConfigration object lacks 'jobid'."
-      return 0
-    endif
+  " Ensure the correct keys exist within the configuration
+  if !(has_key(a:config, 'jobid'))
+    echo "\nConfigration object lacks 'jobid'."
+    return 0
+  endif
 
-    if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
-      echo "\nNo matching job id for the provided pid."
-      return 0
-    endif
+  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
+    echo "\nNo matching job id for the provided pid."
+    return 0
+  endif
 
-    if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
-      echo "\nJob ID not found."
-      return 0
-    endif
+  if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
+    echo "\nJob ID not found."
+    return 0
+  endif
 
-    if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
-      echo "\nJob ID not found."
-      return 0
-    endif
+  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
+    echo "\nJob ID not found."
+    return 0
+  endif
 
-    if empty(jobpid(a:config['jobid']))
-      echo "\nJob ID not linked to a PID."
-      return 0
-    endif
+  if empty(jobpid(a:config['jobid']))
+    echo "\nJob ID not linked to a PID."
+    return 0
+  endif
 
-    return 1
+  return 1
 
-  endfunction
+endfunction

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -223,9 +223,10 @@ function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
   return join(jobpids,"\n")
 endfunction
 
-
-
-
+" Checks if a previous channel does not exist or is empty.
+function! s:NotExistsLastChannel() abort
+  return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
+endfunction
 
 
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -22,7 +22,7 @@ function! slime#targets#neovim#config() abort
     let default_pid = jobpid(b:slime_config["jobid"])
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
-    end
+    endif
     let pid_in = input("pid: ", default_pid)
     let id_in = s:translate_pid_to_id(pid_in)
   else
@@ -32,171 +32,171 @@ function! slime#targets#neovim#config() abort
       let default_jobid = b:slime_config["jobid"]
       if !empty(default_jobid)
         let default_jobid = str2nr(default_jobid)
-      end
+      endif
       let id_in = input("jobid: ", default_jobid)
       let id_in = str2nr(id_in)
     endif
     let pid_in = s:translate_id_to_pid(id_in)
-  endi
-
-  let b:slime_config["jobid"] = id_in
-  let b:slime_config["pid"] = pid_in
-
-  if exists("b:slime_config")
-    if !s:ValidConfig(b:slime_config)
-      unlet b:slime_config
-    endif
   endif
 
-endfunction
+    let b:slime_config["jobid"] = id_in
+    let b:slime_config["pid"] = pid_in
 
-function! slime#targets#neovim#send(config, text)
-  if  s:ValidConfig()
-
-    " Neovim jobsend is fully asynchronous, it causes some problems with
-    " iPython %cpaste (input buffering: not all lines sent over)
-    " So this `write_paste_file` can help as a small lock & delay
-    call slime#common#write_paste_file(a:text)
-    call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
-    " if b:slime_config is {"jobid": ""} and not configured
-    " then unset it for automatic configuration next time
-    if b:slime_config["jobid"]  == ""
-      unlet b:slime_config
-    endif
-
-
-  else "remove invalid configs
-      unlet b:slime_config
-  endif
-endfunction
-
-function! slime#targets#neovim#SlimeAddChannel()
-  if !exists("g:slime_last_channel")
-    let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
-  else
-    call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
-  endif
-endfunction
-
-function! slime#targets#neovim#SlimeClearChannel()
-  let current_buffer_jobid = &channel
-
-  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
-      \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
-
-  for buf in related_bufs
-    call setbufvar(buf['bufnr'], 'slime_config', {})
-  endfor
-    
-  if !exists("g:slime_last_channel")
     if exists("b:slime_config")
+      if !s:ValidConfig(b:slime_config)
+        unlet b:slime_config
+      endif
+    endif
+
+  endfunction
+
+  function! slime#targets#neovim#send(config, text)
+    if  s:ValidConfig()
+
+      " Neovim jobsend is fully asynchronous, it causes some problems with
+      " iPython %cpaste (input buffering: not all lines sent over)
+      " So this `write_paste_file` can help as a small lock & delay
+      call slime#common#write_paste_file(a:text)
+      call chansend(str2nr(a:config["jobid"]), split(a:text, "\n", 1))
+      " if b:slime_config is {"jobid": ""} and not configured
+      " then unset it for automatic configuration next time
+      if b:slime_config["jobid"]  == ""
+        unlet b:slime_config
+      endif
+
+
+    else "remove invalid configs
       unlet b:slime_config
     endif
-    return
-  elseif len(g:slime_last_channel) == 1
-    unlet g:slime_last_channel
-    if exists("b:slime_config")
-      unlet b:slime_config
+  endfunction
+
+  function! slime#targets#neovim#SlimeAddChannel()
+    if !exists("g:slime_last_channel")
+      let g:slime_last_channel = [{'jobid': &channel, 'pid': jobpid(&channel)}]
+    else
+      call add(g:slime_last_channel, {'jobid': &channel, 'pid': jobpid(&channel)})
     endif
-  else
-    let bufinfo = s:get_filter_bufinfo()
+  endfunction
 
-    " tests if using a version of Neovim that
-    " doesn't automatically close buffers when closed
-    " or there is no autocommand that does that
-    if len(bufinfo) == len(g:slime_last_channel)
-      call filter(bufinfo, {_, val -> val != current_buffer_jobid})
+  function! slime#targets#neovim#SlimeClearChannel()
+    let current_buffer_jobid = &channel
+
+    let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
+          \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})
+
+    for buf in related_bufs
+      call setbufvar(buf['bufnr'], 'slime_config', {})
+    endfor
+
+    if !exists("g:slime_last_channel")
+      if exists("b:slime_config")
+        unlet b:slime_config
+      endif
+      return
+    elseif len(g:slime_last_channel) == 1
+      unlet g:slime_last_channel
+      if exists("b:slime_config")
+        unlet b:slime_config
+      endif
+    else
+      let bufinfo = s:get_filter_bufinfo()
+
+      " tests if using a version of Neovim that
+      " doesn't automatically close buffers when closed
+      " or there is no autocommand that does that
+      if len(bufinfo) == len(g:slime_last_channel)
+        call filter(bufinfo, {_, val -> val != current_buffer_jobid})
+      endif
+
+      call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
+
     endif
+  endfunction
 
-    call filter(g:slime_last_channel, {_, val -> index(bufinfo, str2nr(val["jobid"])) >= 0})
+  function! s:get_filter_bufinfo()
+    let bufinfo = getbufinfo()
+    "getting terminal buffers
 
-  endif
-endfunction
+    call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
+          \ && has_key(val['variables'], "terminal_job_pid")
+          \    && get(val,"listed",0)})
+    " only need the job id
+    call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
 
-function! s:get_filter_bufinfo()
-  let bufinfo = getbufinfo()
-  "getting terminal buffers
+    return bufinfo
+  endfunction
 
-  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
-        \ && has_key(val['variables'], "terminal_job_pid")
-        \    && get(val,"listed",0)})
-  " only need the job id
-  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+  function! s:translate_pid_to_id(pid)
+    for ch in g:slime_last_channel
+      if ch['pid'] == a:pid
+        return ch['jobid']
+      endif
+    endfor
+    return -1
+  endfunction
 
-  return bufinfo
-endfunction
-
-function! s:translate_pid_to_id(pid)
-  for ch in g:slime_last_channel
-    if ch['pid'] == a:pid
-      return ch['jobid']
-    endif
-  endfor
-  return -1
-endfunction
-
-function! s:translate_id_to_pid(id)
-  let pid_out = -1
-  try
-    let pid_out = jobpid(a:id)
-  catch /E900: Invalid channel id/
+  function! s:translate_id_to_pid(id)
     let pid_out = -1
-  endtry
-  return pid_out
-endfunction
+    try
+      let pid_out = jobpid(a:id)
+    catch /E900: Invalid channel id/
+      let pid_out = -1
+    endtry
+    return pid_out
+  endfunction
 
 
-" "checks that a configuration is valid
-" returns boolean of whether the supplied config is valid
-function! s:ValidConfig(config) abort
+  " "checks that a configuration is valid
+  " returns boolean of whether the supplied config is valid
+  function! s:ValidConfig(config) abort
 
-  if s:NotExistsLastChannel()
-    echo "\nTerminal not detected."
-    return 0
-  endif
+    if s:NotExistsLastChannel()
+      echo "\nTerminal not detected."
+      return 0
+    endif
 
-  if !exists("a:config") ||  a:config is v:null
-    echo "\nConfig does not exist."
-    return 0
-  endif
+    if !exists("a:config") ||  a:config is v:null
+      echo "\nConfig does not exist."
+      return 0
+    endif
 
-  " Ensure the config is a dictionary and a previous channel exists
-  if type(a:config) != v:t_dict
-    echo "\nConfig type not valid."
-    return 0
-  endif
+    " Ensure the config is a dictionary and a previous channel exists
+    if type(a:config) != v:t_dict
+      echo "\nConfig type not valid."
+      return 0
+    endif
 
-  if empty(a:config)
-    echo "\nConfig is empty."
-    return 0
-  endif
+    if empty(a:config)
+      echo "\nConfig is empty."
+      return 0
+    endif
 
-  " Ensure the correct keys exist within the configuration
-  if !(has_key(a:config, 'jobid'))
-    echo "\nConfigration object lacks 'jobid'."
-    return 0
-  endif
+    " Ensure the correct keys exist within the configuration
+    if !(has_key(a:config, 'jobid'))
+      echo "\nConfigration object lacks 'jobid'."
+      return 0
+    endif
 
-  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
-    echo "\nNo matching job id for the provided pid."
-    return 0
-  endif
+    if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
+      echo "\nNo matching job id for the provided pid."
+      return 0
+    endif
 
-  if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
-    echo "\nJob ID not found."
-    return 0
-  endif
+    if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
+      echo "\nJob ID not found."
+      return 0
+    endif
 
-  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
-    echo "\nJob ID not found."
-    return 0
-  endif
+    if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
+      echo "\nJob ID not found."
+      return 0
+    endif
 
-  if empty(jobpid(a:config['jobid']))
-    echo "\nJob ID not linked to a PID."
-    return 0
-  endif
+    if empty(jobpid(a:config['jobid']))
+      echo "\nJob ID not linked to a PID."
+      return 0
+    endif
 
-  return 1
+    return 1
 
-endfunction
+  endfunction

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -105,7 +105,7 @@ function! slime#targets#neovim#SlimeClearChannel()
       unlet b:slime_config
     endif
   else
-    let bufinfo = s:get_filter_bufinfo()
+    let bufinfo = s:get_terminal_jobids()
 
     " tests if using a version of Neovim that
     " doesn't automatically close buffers when closed
@@ -121,18 +121,6 @@ endfunction
 
 
 
-function! s:get_filter_bufinfo()
-  let bufinfo = getbufinfo()
-  "getting terminal buffers
-
-  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
-        \ && has_key(val['variables'], "terminal_job_pid")
-        \    && get(val,"listed",0)})
-  " only need the job id
-  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
-
-  return bufinfo
-endfunction
 
 function! s:translate_pid_to_id(pid)
   for ch in g:slime_last_channel
@@ -209,7 +197,7 @@ function! s:ValidConfig(config, silent) abort
     return 0
   endif
 
-  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
+  if !(index(s:get_terminal_jobids(), a:config['jobid']) >= 0)
     if !a:silent
       echo "\nJob ID not found."
     endif
@@ -227,6 +215,18 @@ function! s:ValidConfig(config, silent) abort
 
 endfunction
 
+function! s:get_terminal_jobids()
+  let bufinfo = getbufinfo()
+  "getting terminal buffers
+
+  call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id")
+        \ && has_key(val['variables'], "terminal_job_pid")
+        \    && get(val,"listed",0)})
+  " only need the job id
+  call map(bufinfo, {_, val -> val["variables"]["terminal_job_id"] })
+
+  return bufinfo
+endfunction
 
 "evaluates whether there is a terminal running; if there isn't then no config can be valid
 function! s:ValidEnv() abort

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -141,6 +141,14 @@ function! s:translate_id_to_pid(id)
   return pid_out
 endfunction
 
+"evaluates whether there is a terminal running; if there isn't then no config can be valid
+function! s:ValidEnv() abort
+  if s:NotExistsLastChannel()
+    echo "Terminal not detected."
+    return 0
+  endif
+  return 1
+endfunction
 
 " "checks that a configuration is valid
 " returns boolean of whether the supplied config is valid
@@ -228,14 +236,6 @@ function! s:get_terminal_jobids()
   return bufinfo
 endfunction
 
-"evaluates whether there is a terminal running; if there isn't then no config can be valid
-function! s:ValidEnv() abort
-  if s:NotExistsLastChannel()
-    echo "Terminal not detected."
-    return 0
-  endif
-  return 1
-endfunction
 
 function! s:last_channel_to_jobid_array(channel_dict)
   return map(copy(a:channel_dict), {_, val -> val["jobid"]})

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -228,7 +228,7 @@ function! s:ValidConfig(config, silent) abort
 endfunction
 
 
-"evaluates whether ther is a terminal running; if there isn't then no config can be valid
+"evaluates whether there is a terminal running; if there isn't then no config can be valid
 function! s:ValidEnv() abort
   if s:NotExistsLastChannel()
     echo "Terminal not detected."

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -202,29 +202,25 @@ function! s:ValidConfig(config) abort
 endfunction
 
 
-
-" Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
-" for teh purposes of input completion
 function! s:last_channel_to_jobid_array(channel_dict)
   return map(copy(a:channel_dict), {_, val -> val["jobid"]})
 endfunction
 
+" Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
+" for the purposes of input completion
 function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by theier final identity
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
   return join(jobids,"\n")
-
 endfunction
 
-" Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job IDs.
+" Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
 function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by theier final identity
+  "they will be transformed into pids so caling them by their final identity
   let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   map(job_pids, {_, val -> s:translate_id_to_pid(val)})
   call filter(job_pids, {_,val -> val != -1})
   return join(jobpids,"\n")
-
 endfunction
 
 

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -25,7 +25,7 @@ function! slime#targets#neovim#config() abort
       if !empty(default_pid)
         let default_pid = str2nr(default_pid)
       endif
-      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
+      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,Last_channel_to_pid_string')
       let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
     else
       if exists("g:slime_get_jobid")
@@ -35,7 +35,7 @@ function! slime#targets#neovim#config() abort
         if !empty(default_jobid)
           let default_jobid = str2nr(default_jobid)
         endif
-        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,s:last_channel_to_jobid_string')
+        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,Last_channel_to_jobid_string')
         let jobid_in = str2nr(jobid_in)
       endif
       let pid_in = s:translate_id_to_pid(jobid_in)
@@ -243,14 +243,14 @@ endfunction
 
 " Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
-function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+function! Last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
   return join(jobids,"\n")
 endfunction
 
 " Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
-function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
+function! Last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
   "they will be transformed into pids so caling them by their final identity
   let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
   map(job_pids, {_, val -> s:translate_id_to_pid(val)})
@@ -262,9 +262,6 @@ endfunction
 function! s:NotExistsLastChannel() abort
   return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
 endfunction
-
-
-
 
 " clears all buffers with a certain invalid configuration
 function! s:clear_related_bufs(id_in)
@@ -282,4 +279,3 @@ function! s:sure_clear_buf_config()
     call s:clear_related_bufs(b:slime_config['jobid'])
   endif
 endfunction
-

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -25,7 +25,7 @@ function! slime#targets#neovim#config() abort
       if !empty(default_pid)
         let default_pid = str2nr(default_pid)
       endif
-      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,Last_channel_to_pid_string')
+      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
       let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
     else
       if exists("g:slime_get_jobid")
@@ -35,7 +35,7 @@ function! slime#targets#neovim#config() abort
         if !empty(default_jobid)
           let default_jobid = str2nr(default_jobid)
         endif
-        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,Last_channel_to_jobid_string')
+        let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
         let jobid_in = str2nr(jobid_in)
       endif
       let pid_in = s:translate_id_to_pid(jobid_in)
@@ -243,19 +243,21 @@ endfunction
 
 " Transforms a channel dictionary with job id and pid into an newline separated string  of job IDs.
 " for the purposes of input completion
-function! Last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+function! Last_channel_to_jobid(ArgLead, CmdLine, CursorPos)
   let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
-  return join(jobids,"\n")
+  call map(jobids, {_, val -> string(val)})
+  return jobids
 endfunction
 
 " Transforms a channel dictionary with job ida and pid into an newline separated string  of job PIDs.
 " for the purposes of input completion
-function! Last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
-  "they will be transformed into pids so caling them by their final identity
-  let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
-  map(job_pids, {_, val -> s:translate_id_to_pid(val)})
-  call filter(job_pids, {_,val -> val != -1})
-  return join(jobpids,"\n")
+function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so naming them by their final identity
+  let jobpids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
+  call map(jobpids, {_, val -> s:translate_id_to_pid(val)})
+  call filter(jobpids, {_,val -> val != -1})
+  call map(jobpids, {_, val -> string(val)})
+  return jobpids
 endfunction
 
 " Checks if a previous channel does not exist or is empty.

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -23,23 +23,23 @@ function! slime#targets#neovim#config() abort
     if !empty(default_pid)
       let default_pid = str2nr(default_pid)
     endif
-    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid)
-    let id_in = s:translate_pid_to_id(pid_in)
+    let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'custom,s:last_channel_to_pid_string')
+    let jobid_in = str2nr(s:translate_pid_to_id(pid_in))
   else
     if exists("g:slime_get_jobid")
-      let id_in = g:slime_get_jobid()
+      let jobid_in = g:slime_get_jobid()
     else
       let default_jobid = b:slime_config["jobid"]
       if !empty(default_jobid)
         let default_jobid = str2nr(default_jobid)
       endif
-      let id_in = input("Configuring vim-slime. Input jobid: ", default_jobid)
-      let id_in = str2nr(id_in)
+      let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'custom,s:last_channel_to_jobid_string')
+      let jobid_in = str2nr(jobid_in)
     endif
-    let pid_in = s:translate_id_to_pid(id_in)
+    let pid_in = s:translate_id_to_pid(jobid_in)
   endif
 
-  let b:slime_config["jobid"] = id_in
+  let b:slime_config["jobid"] = jobid_in
   let b:slime_config["pid"] = pid_in
 
   if exists("b:slime_config")

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -29,9 +29,9 @@ function! slime#targets#neovim#config() abort
     if exists("g:slime_get_jobid")
       let id_in = g:slime_get_jobid()
     else
-      let default_jid = b:slime_config["jobid"]
-      if !empty(default_jid)
-        let default_jid = str2nr(default_jobid)
+      let default_jobid = b:slime_config["jobid"]
+      if !empty(default_jobid)
+        let default_jobid = str2nr(default_jobid)
       end
       let id_in = input("jobid: ", default_jobid)
       let id_in = str2nr(id_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -122,24 +122,6 @@ endfunction
 
 
 
-function! s:translate_pid_to_id(pid)
-  for ch in g:slime_last_channel
-    if ch['pid'] == a:pid
-      return ch['jobid']
-    endif
-  endfor
-  return -1
-endfunction
-
-function! s:translate_id_to_pid(id)
-  let pid_out = -1
-  try
-    let pid_out = jobpid(a:id)
-  catch /E900: Invalid channel id/
-    let pid_out = -1
-  endtry
-  return pid_out
-endfunction
 
 "evaluates whether there is a terminal running; if there isn't then no config can be valid
 function! s:ValidEnv() abort
@@ -223,6 +205,30 @@ function! s:ValidConfig(config, silent) abort
 
 endfunction
 
+function! s:translate_pid_to_id(pid)
+  for ch in g:slime_last_channel
+    if ch['pid'] == a:pid
+      return ch['jobid']
+    endif
+  endfor
+  return -1
+endfunction
+
+function! s:translate_id_to_pid(id)
+  let pid_out = -1
+  try
+    let pid_out = jobpid(a:id)
+  catch /E900: Invalid channel id/
+    let pid_out = -1
+  endtry
+  return pid_out
+endfunction
+
+" Checks if a previous channel does not exist or is empty.
+function! s:NotExistsLastChannel() abort
+  return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
+endfunction
+
 function! s:get_terminal_jobids()
   let bufinfo = getbufinfo()
   "getting terminal buffers
@@ -260,10 +266,6 @@ function! Last_channel_to_pid(ArgLead, CmdLine, CursorPos)
   return jobpids
 endfunction
 
-" Checks if a previous channel does not exist or is empty.
-function! s:NotExistsLastChannel() abort
-  return (!exists("g:slime_last_channel") || (len(g:slime_last_channel)) < 1)
-endfunction
 
 " clears all buffers with a certain invalid configuration
 function! s:clear_related_bufs(id_in)

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -182,7 +182,7 @@ function! s:ValidConfig(config) abort
     return 0
   endif
 
-  if !(index( s:channel_to_array(g:slime_last_channel), a:config['jobid']) >= 0)
+  if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), a:config['jobid']) >= 0)
     echo "\nJob ID not found."
     return 0
   endif
@@ -200,3 +200,37 @@ function! s:ValidConfig(config) abort
   return 1
 
 endfunction
+
+
+
+" Transforms a channel dictionary with job id and pid into an newline seaparated string  of job IDs.
+" for teh purposes of input completion
+function! s:last_channel_to_jobid_array(channel_dict)
+  return map(copy(a:channel_dict), {_, val -> val["jobid"]})
+endfunction
+
+function! s:last_channel_to_jobid_string(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so caling them by theier final identity
+  let jobids = s:last_channel_to_jobid_array(g:slime_last_channel)
+  return join(jobids,"\n")
+
+endfunction
+
+" Transforms a channel dictionary with job ida and pid into an newline seaparated string  of job IDs.
+" for the purposes of input completion
+function! s:last_channel_to_pid_string(ArgLead, CmdLine, CursorPos)
+  "they will be transformed into pids so caling them by theier final identity
+  let job_pids = map(copy(g:slime_last_channel), {_, val -> val["jobid"]})
+  map(job_pids, {_, val -> s:translate_id_to_pid(val)})
+  call filter(job_pids, {_,val -> val != -1})
+  return join(jobpids,"\n")
+
+endfunction
+
+
+
+
+
+
+
+

--- a/autoload/slime/targets/neovim.vim
+++ b/autoload/slime/targets/neovim.vim
@@ -64,7 +64,7 @@ function! slime#targets#neovim#SlimeAddChannel()
 endfunction
 
 function! slime#targets#neovim#SlimeClearChannel()
-  let current_buffer_jobid = get(b:,"terminal_job_id",-1)
+  let current_buffer_jobid = &channel
 
   let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
       \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})


### PR DESCRIPTION
# Intro

You opened [this pr](https://github.com/jpalardy/vim-slime/pull/416).  I let you know that I had been working on very similar things, and that it involved changes to the core plugin.  Then jpalardy replied that changes to the core plugin might not be welcomed.  So I refoactored what I had worked on to incorporate your code from that PR, and added some additional new features, and focused the changes in the neovim target code. 


Sorry this explanation is so long! I always prefer verbose explanations but I know some people don't.

If you accept this PR, the changes will transfer over to the PR on jpalardy's main repo. I can then recommend that that PR be accepted. Let me know what you think!


## Your Previous Contributions

### extra `get` call/validation

Your code has:

```vim
    let last_pid = get(get(get(g:, 'slime_last_channel', []), -1, {}), 'pid', '')
    let last_job = get(get(get(g:, 'slime_last_channel', []), -1, {}), 'jobid', '')
```

The third call  `get` adds safety but split it up into one call per line so that it's easier to read:

```vim

      let last_channels = get(g:, 'slime_last_channel', [])
      let most_recent_channel = get(last_channels, -1, {})

      let last_pid = get(most_recent_channel, 'pid', '')
      let last_job = get(most_recent_channel, 'jobid', '')
```

I incorporate your validation in case the `get` calls return an empty config.

```vim
      let default_pid = jobpid(b:slime_config["jobid"])
      if !empty(default_pid)
        let default_pid = str2nr(default_pid)
      endif
```

and

```vim
        let default_jobid = b:slime_config["jobid"]
        if !empty(default_jobid)
          let default_jobid = str2nr(default_jobid)
        endif
```


### Clearing Invalid Configurations


You have the code:

```vim
 let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
      \ && get(val['variables']['slime_config'], 'jobid', -2) == current_buffer_jobid})

  for buf in related_bufs
    call setbufvar(buf['bufnr'], 'slime_config', {})
  endfor
```


I use it to but I move it to its own function

```vim
function! s:clear_related_bufs(id_in)
  let related_bufs = filter(getbufinfo(), {_, val -> has_key(val['variables'], "slime_config")
        \ && get(val['variables']['slime_config'], 'jobid', -2) == a:id_in})

  for buf in related_bufs
    call setbufvar(buf['bufnr'], 'slime_config', {})
  endfor
endfunction
```

and used this function in several places. 


### core s:SlimeGetConfig functiion

I keep

```vim
 if exists("b:slime_config") && !empty(b:slime_config)
```

## My New Contributions


### Validation Functions
#### The `ValidConfig` function in the Neovim target file:

```vim

" "checks that a configuration is valid
" returns boolean of whether the supplied config is valid
function! s:ValidConfig(config, silent) abort

  if s:NotExistsLastChannel()
    if !a:silent
      echo "\nTerminal not detected."
    endif
    return 0
  endif

  if !exists("a:config") ||  a:config is v:null
    if !a:silent
      echo "\nConfig does not exist."
    endif
    return 0
  endif

  " Ensure the config is a dictionary and a previous channel exists
  if type(a:config) != v:t_dict
    if !a:silent
      echo "\nConfig type not valid."
    endif
    return 0
  endif

  if empty(a:config)
    if !a:silent
      echo "\nConfig is empty."
    endif
    return 0
  endif

  " Ensure the correct keys exist within the configuration
  if !(has_key(a:config, 'jobid'))
    if !a:silent
      echo "\nConfigration object lacks 'jobid'."
    endif
    return 0
  endif

  if a:config["jobid"] == -1  "the id wasn't found translate_pid_to_id
    if !a:silent
      echo "\nNo matching job id for the provided pid."
    endif
    return 0
  endif

  if !(index( s:last_channel_to_jobid_array(g:slime_last_channel), a:config['jobid']) >= 0)
    if !a:silent
      echo "\nJob ID not found."
    endif
    return 0
  endif

  if !(index(s:get_filter_bufinfo(), a:config['jobid']) >= 0)
    if !a:silent
      echo "\nJob ID not found."
    endif
    return 0
  endif

  if empty(jobpid(a:config['jobid']))
    if !a:silent
      echo "\nJob ID not linked to a PID."
    endif
    return 0
  endif

  return 1

endfunction
```

This checks almost everything that can make a config invalid.


#### `ValidEnv` 

checks if the environment is valid, specifically if a terminal is open. If this is not the case then no config can work.

```vim
"evaluates whether ther is a terminal running; if there isn't then no config can be valid
function! s:ValidEnv() abort
  if s:NotExistsLastChannel()
    echo "Terminal not detected."
    return 0
  endif
  return 1
endfunction
```


### Completeion

In the I added completion ability to the `input()` functions.



```vim
      let pid_in = input("Configuring vim-slime. Input pid: ", default_pid , 'customlist,Last_channel_to_pid')
```

and

```vim
      let jobid_in = input("Configuring vim-slime. Input jobid: ", default_jobid, 'customlist,Last_channel_to_jobid')
```

with the completion functions available in the file.


### Using the Validation Functions

#### Validating the Environment

I wrapped all of `slime#targets#neovim#config()` in a call to `s:ValidEnv()` to make sure to not even try to configure when it is not possible. 


#### Validating the Config

I call `s:ValidConfig()` in three places.  When it is not valid I call `s:sure_clear_buf_config()` which is a small wrapper of `s:clear_related_bufs(id_in)` which clears invalid configs from other buffers. In appopriate places I also unlet `b:slime_confi` when the config is not valid.
